### PR TITLE
Relax fido2 constraint to >= 1.1.0, < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'ua-parser',
         'user-agents',
         'python-jose',
-        'fido2 == 1.0.0',
+        'fido2 >= 1.1.0, < 2',
         'jsonLookup'
       ],
     python_requires=">=3.5",


### PR DESCRIPTION
## Summary

Follow-up to #6. The `fido2 == 1.0.0` pin from upstream 2.5.1 caps `cryptography < 40`, which conflicts with galaxy's `cryptography == 43.0.1` and makes galaxy's dependency resolution unsolvable.

Upstream relaxed to `fido2 >= 1.1.0` in v2.9 while keeping the same FIDO2 API call sites (their v2.8 → v2.9 diff is formatting and import cleanup only), and fido2 1.1+/1.2 allows `cryptography < 45`, which fits galaxy. Capped at `< 2` because python-fido2 2.0 removed the older call signatures this code uses.